### PR TITLE
Bundle Plyr and model-viewer locally

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -13,9 +13,6 @@
   <link rel="dns-prefetch" href="https://youtube.com">
   <link rel="dns-prefetch" href="https://vimeo.com">
   
-  <!-- Preload Plyr CSS for video content -->
-  <link rel="preload" href="https://cdn.plyr.io/3.7.8/plyr.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css"></noscript>
 </head>
 <body>
   <div id="learning-object-container"></div>
@@ -66,26 +63,6 @@
         console.log('🎉 Wrapper ready!');
         
         const { wrapper: wrapperInstance, config: wrapperConfig } = event.detail;
-        
-        // Performance optimization: preload resources based on content type
-        const contentType = config.type;
-        if (contentType === 'video' || contentType === 'auto') {
-          // Preload Plyr JavaScript for video content
-          const script = document.createElement('link');
-          script.rel = 'preload';
-          script.href = 'https://cdn.plyr.io/3.7.8/plyr.polyfilled.js';
-          script.as = 'script';
-          document.head.appendChild(script);
-        }
-        
-        if (contentType === 'model' || contentType === 'auto') {
-          // Preload model-viewer for 3D content
-          const script = document.createElement('link');
-          script.rel = 'preload';
-          script.href = 'https://unpkg.com/@google/model-viewer@^3.4.0/dist/model-viewer.min.js';
-          script.as = 'script';
-          document.head.appendChild(script);
-        }
         
         // Parse captions from URL parameters
         const captions = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,183 @@
+{
+  "name": "lor-wrapper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lor-wrapper",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@google/model-viewer": "^4.1.0",
+        "plyr": "^3.7.8"
+      }
+    },
+    "node_modules/@google/model-viewer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-4.1.0.tgz",
+      "integrity": "sha512-7WB/jS6wfBfRl/tWhsUUvDMKFE1KlKME97coDLlZQfvJD0nCwjhES1lJ+k7wnmf7T3zMvCfn9mIjM/mgZapuig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@monogrid/gainmap-js": "^3.1.0",
+        "lit": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "three": "^0.172.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
+      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
+      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.1.0.tgz",
+      "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
+      "integrity": "sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/custom-event-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==",
+      "license": "MIT"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
+      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
+      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
+      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/loadjs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.3.0.tgz",
+      "integrity": "sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/plyr": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.7.8.tgz",
+      "integrity": "sha512-yG/EHDobwbB/uP+4Bm6eUpJ93f8xxHjjk2dYcD1Oqpe1EcuQl5tzzw9Oq+uVAzd2lkM11qZfydSiyIpiB8pgdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.26.1",
+        "custom-event-polyfill": "^1.0.7",
+        "loadjs": "^4.2.0",
+        "rangetouch": "^2.0.1",
+        "url-polyfill": "^1.1.12"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/rangetouch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rangetouch/-/rangetouch-2.0.1.tgz",
+      "integrity": "sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==",
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.172.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
+      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/url-polyfill": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.13.tgz",
+      "integrity": "sha512-tXzkojrv2SujumYthZ/WjF7jaSfNhSXlYMpE5AYdL2I3D7DCeo+mch8KtW2rUuKjDg+3VXODXHVgipt8yGY/eQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
     "start": "python3 -m http.server 8000"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "@google/model-viewer": "^4.1.0",
+    "plyr": "^3.7.8"
+  }
 }

--- a/plugins/modelPlugin.js
+++ b/plugins/modelPlugin.js
@@ -1,3 +1,6 @@
+import '@google/model-viewer';
+import '@google/model-viewer/dist/model-viewer.css';
+
 /**
  * 3D Model Content Plugin
  * Enhanced model-viewer integration with controls and AR support
@@ -17,33 +20,8 @@ export const modelPlugin = {
     console.log('🚀 Loading 3D model:', src);
     const container = wrapper.getContentContainer();
     
-    // Dynamically import model-viewer if not already loaded
-    if (!customElements.get('model-viewer')) {
-      console.log('Loading model-viewer module...');
-      try {
-        await import('https://unpkg.com/@google/model-viewer@^3.4.0/dist/model-viewer.min.js');
-        console.log('✅ Model-viewer module loaded');
-      } catch (error) {
-        console.error('❌ Failed to load model-viewer module:', error);
-        throw new Error('Failed to load model-viewer library');
-      }
-      
-      // Load model-viewer CSS
-      if (!document.querySelector('link[href*="model-viewer"]')) {
-        const link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.href = 'https://unpkg.com/@google/model-viewer@^3.4.0/dist/model-viewer.css';
-        document.head.appendChild(link);
-        console.log('📄 Model-viewer CSS loaded');
-      }
-    } else {
-      console.log('✅ Model-viewer already available');
-    }
-    
-    // Wait for custom element to be fully defined first
-    if (customElements.get('model-viewer')) {
-      await customElements.whenDefined('model-viewer');
-    }
+    // Ensure model-viewer custom element is defined
+    await customElements.whenDefined('model-viewer');
     
     // Create unique model ID
     const modelId = 'model-' + Math.random().toString(36).substr(2, 9);

--- a/plugins/videoPlugin.js
+++ b/plugins/videoPlugin.js
@@ -1,3 +1,6 @@
+import Plyr from 'plyr';
+import 'plyr/dist/plyr.css';
+
 /**
  * Video Content Plugin
  * Handles video content with Plyr player integration
@@ -71,61 +74,16 @@ export const videoPlugin = {
       </div>`;
 
     try {
-      // Load Plyr if not already available
-      if (!window.Plyr) {
-        console.log('Loading Plyr...');
-        
-        // Load Plyr CSS first
-        if (!document.querySelector('link[href*="plyr.css"]')) {
-          const link = document.createElement('link');
-          link.rel = 'stylesheet';
-          link.href = 'https://cdn.plyr.io/3.7.8/plyr.css';
-          document.head.appendChild(link);
-          
-          // Wait for CSS to load
-          await new Promise((resolve) => {
-            link.onload = resolve;
-            link.onerror = resolve; // Continue even if CSS fails
-          });
-        }
-        
-        // Load Plyr JS
-        const script = document.createElement('script');
-        script.src = 'https://cdn.plyr.io/3.7.8/plyr.polyfilled.js';
-        document.head.appendChild(script);
-        
-        // Wait for Plyr to load with timeout
-        await new Promise((resolve) => {
-          const timeout = setTimeout(() => {
-            console.warn('Plyr loading timeout');
-            resolve(); // Continue without Plyr
-          }, 5000);
-          
-          script.onload = () => {
-            clearTimeout(timeout);
-            console.log('Plyr loaded successfully');
-            resolve();
-          };
-          
-          script.onerror = () => {
-            clearTimeout(timeout);
-            console.error('Failed to load Plyr');
-            resolve(); // Continue without Plyr
-          };
-        });
-      }
-
       // Wait for DOM to be ready
       await new Promise(resolve => setTimeout(resolve, 200));
 
-      // Initialize Plyr if available
+      // Initialize Plyr
       const videoElement = container.querySelector(`#${videoId}`);
       console.log('Video element found:', !!videoElement);
-      console.log('Plyr available:', !!window.Plyr);
-      
-      if (videoElement && window.Plyr) {
+
+      if (videoElement) {
         console.log('Initializing Plyr for video:', videoId);
-        
+
         try {
           // Initialize with all controls available (Plyr will handle responsive behavior)
           let player = new Plyr(videoElement, {
@@ -135,23 +93,23 @@ export const videoPlugin = {
             // Let Plyr handle responsive controls internally
             responsive: true
           });
-          
+
           // Add resize listener to trigger wrapper resize without recreating player
           let resizeTimer;
-          
+
           const handleResize = () => {
             clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => {
               console.log('🔄 Video resize detected, updating wrapper size:', window.innerWidth);
-              
+
               // Just trigger wrapper resize - let Plyr handle its own responsive behavior
               wrapper.triggerResize();
-              
+
               // Hide/show volume slider (not mute) and PiP based on screen size
               const volumeSlider = container.querySelector('.plyr__volume input[type="range"]');
               const pipButton = container.querySelector('[data-plyr="pip"]');
               const airplayButton = container.querySelector('[data-plyr="airplay"]');
-              
+
               if (window.innerWidth <= 480) {
                 // Mobile - hide volume slider but keep mute button and settings
                 if (volumeSlider) volumeSlider.style.display = 'none';
@@ -163,7 +121,7 @@ export const videoPlugin = {
                 if (pipButton) pipButton.style.display = '';
                 if (airplayButton) airplayButton.style.display = '';
               }
-              
+
               // Force a more aggressive resize notification
               setTimeout(() => {
                 // Use forceResize to bypass threshold when controls change
@@ -175,9 +133,9 @@ export const videoPlugin = {
               }, 100);
             }, 250);
           };
-          
+
           window.addEventListener('resize', handleResize);
-          
+
           // Apply initial responsive controls
           setTimeout(() => handleResize(), 100);
 
@@ -186,7 +144,7 @@ export const videoPlugin = {
             playerInstance.on('ready', () => {
               console.log('✅ Plyr player ready');
               wrapperInstance.trackContentEvent('video_ready', 'Video Player', 'Plyr initialized');
-              
+
               // Multiple resize attempts after ready
               setTimeout(() => wrapperInstance.triggerResize(), 100);
               setTimeout(() => wrapperInstance.triggerResize(), 500);
@@ -260,16 +218,16 @@ export const videoPlugin = {
           attachPlayerEvents(player, wrapper);
 
           return player;
-          
+
         } catch (plyrError) {
           console.error('Failed to initialize Plyr:', plyrError);
           console.log('Falling back to basic video controls');
         }
       } else {
-        console.warn('Plyr not available, using basic video controls');
+        console.warn('Video element not found, using basic video controls');
       }
     } catch (error) {
-      console.error('Error loading Plyr:', error);
+      console.error('Error initializing Plyr:', error);
       console.log('Using basic video controls');
     }
 


### PR DESCRIPTION
## Summary
- Install Plyr and @google/model-viewer as project dependencies
- Remove preload links and external script references from `embed.html`
- Import Plyr and model-viewer directly inside their plugin modules so bundlers include them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892e0aa544483318025453c3028e0ea