### PR TITLE
feat: lazily load plugin dependencies

### DIFF
--- a/contentPlugins.js
+++ b/contentPlugins.js
@@ -3,6 +3,15 @@
  * Each plugin is now in a separate file for better maintainability
  */
 
+const pluginLoaders = {
+  video: () => import('./plugins/video/index.js').then(m => m.videoPlugin.load),
+  model: () => import('./plugins/model/index.js').then(m => m.modelPlugin.load),
+  pdf: () => import('./plugins/iframe/index.js').then(m => m.iframePlugin.load),
+  h5p: () => import('./plugins/h5p/index.js').then(m => m.h5pPlugin.load),
+  supersplat: () => import('./plugins/supersplat/index.js').then(m => m.superSplatPlugin.load),
+  iframe: () => import('./plugins/iframe/index.js').then(m => m.iframePlugin.load)
+};
+
 export const contentPlugins = {
   /**
    * Dynamically load a content plugin based on type
@@ -10,33 +19,8 @@ export const contentPlugins = {
    * @returns {Promise<Function>} Plugin load function
    */
   async getPlugin(type) {
-    switch (type) {
-      case 'video': {
-        const { videoPlugin } = await import('./plugins/video/index.js');
-        return videoPlugin.load;
-      }
-      case 'model': {
-        const { modelPlugin } = await import('./plugins/model/index.js');
-        return modelPlugin.load;
-      }
-      case 'pdf': {
-        const { iframePlugin } = await import('./plugins/iframe/index.js');
-        return iframePlugin.load;
-      }
-      case 'h5p': {
-        const { h5pPlugin } = await import('./plugins/h5p/index.js');
-        return h5pPlugin.load;
-      }
-      case 'supersplat': {
-        const { superSplatPlugin } = await import('./plugins/supersplat/index.js');
-        return superSplatPlugin.load;
-      }
-      case 'iframe':
-      default: {
-        const { iframePlugin } = await import('./plugins/iframe/index.js');
-        return iframePlugin.load;
-      }
-    }
+    const loader = pluginLoaders[type] || pluginLoaders.iframe;
+    return loader();
   },
 
   /**

--- a/plugins/model/index.js
+++ b/plugins/model/index.js
@@ -1,6 +1,3 @@
-import '@google/model-viewer';
-import './style.css';
-
 /**
  * 3D Model Content Plugin
  * Enhanced model-viewer integration with controls and AR support
@@ -17,6 +14,11 @@ export const modelPlugin = {
    * @param {string} [config.alt] - Alt text for accessibility
    */
   async load(wrapper, { src, iosSrc, title = '', alt = '3D model' }) {
+    await Promise.all([
+      import('@google/model-viewer'),
+      import('./style.css')
+    ]);
+
     console.log('🚀 Loading 3D model:', src);
     const container = wrapper.getContentContainer();
     

--- a/plugins/video/index.js
+++ b/plugins/video/index.js
@@ -1,6 +1,3 @@
-import Plyr from 'plyr';
-import './plyr.css';
-
 /**
  * Video Content Plugin
  * Handles video content with Plyr player integration
@@ -17,6 +14,11 @@ export const videoPlugin = {
    * @param {string} [config.poster] - Optional poster image URL for HTML5 videos
    */
   async load(wrapper, { src, title = '', captions = [], poster = '' }) {
+    const [{ default: Plyr }] = await Promise.all([
+      import('plyr'),
+      import('./plyr.css')
+    ]);
+
     console.log('🎬 Loading video:', src);
     console.log('🎬 Video config received:', { src, title, captions, poster });
     


### PR DESCRIPTION
## Summary
- add plugin loader registry to centralize dynamic imports
- lazily import heavy dependencies for video and model plugins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f8990ccc833199be5f26233f0fb2